### PR TITLE
feat: Convert some intermediate BAM files into CRAM files

### DIFF
--- a/src/bpipe.config
+++ b/src/bpipe.config
@@ -665,15 +665,6 @@ stages {
         container='gatk'
     }
 
-    add_sample_read_group {
-        modules=default_modules
-        queue='prod_med'
-        walltime="04:00:00"
-        procs=4
-        memory="32g"
-        container='common_tools'
-    }
-
     minimap2_align { 
         modules=default_modules
         queue='prod_long'
@@ -722,97 +713,6 @@ stages {
         container='gatk'
     }
 
-    /*
-    make_clair3_chunks {
-        modules=default_modules
-        walltime="2:00:00"
-        procs=4
-        memory="8g"
-        container='clair3'
-    }
-
-    pileup_variants {
-        modules=default_modules
-        walltime="4:00:00"
-        procs=1
-        memory="8g"
-        container='clair3'
-    }
-
-    aggregate_pileup_variants {
-        modules=default_modules
-        walltime="2:00:00"
-        procs=1
-        memory="8g"
-        container='clair3'
-    }
-
-    select_het_snps {
-        modules=default_modules
-        walltime="2:00:00"
-        procs=1
-        memory="16g"
-        container='clair3'
-    }
-
-    phase_contig {
-        modules=default_modules
-        walltime="4:00:00"
-        procs=4
-        memory="16g"
-        container='clair3'
-    }
-
-    get_qual_filter {
-        modules=default_modules
-        walltime="2:00:00"
-        procs=1
-        memory="8g"
-        container='clair3'
-    }
-
-    create_candidates {
-        modules=default_modules
-        walltime="2:00:00"
-        procs=1
-        memory="8g"
-        container='clair3'
-    }
-
-    evaluate_candidates {
-        modules=default_modules
-        walltime="2:00:00"
-        procs=1
-        memory="8g"
-        container='clair3'
-        quiet=true  
-    }
-
-    aggregate_full_align_variants {
-        modules=default_modules
-        walltime="4:00:00"
-        procs=1
-        memory="8g"
-        container='clair3'
-    }
-
-    merge_pileup_and_full_vars {
-        modules=default_modules
-        walltime="4:00:00"
-        procs=1
-        memory="8g"
-        container='clair3'
-    }
-
-    aggregate_all_variants {
-        modules=default_modules
-        walltime="4:00:00"
-        procs=1
-        memory="8g"
-        container='clair3'
-    }
-    */
-
     phase_variants {
         modules=default_modules
         walltime="6:00:00"
@@ -825,7 +725,7 @@ stages {
         modules=default_modules
         walltime="6:00:00"
         procs=4
-        memory="16g"
+        memory="32g"
         container='clair3'
     }
 
@@ -1029,6 +929,15 @@ stages {
         procs=1
         memory="8g"
     }
+
+    zip_ref {
+        modules=default_modules
+        queue='prod_short'
+        walltime="1:00:00"
+        procs=1
+        memory="8g"
+        container = "common_tools"
+    }
 }
 
 commands {
@@ -1046,5 +955,19 @@ commands {
         modules=default_modules
         container='strvctvre'
         conda_env="StrVCTVRE_py_3";
+    }
+
+    replace_read_group {
+        modules=default_modules
+        queue='prod_med'
+        walltime="04:00:00"
+        procs=4
+        memory="32g"
+        container='common_tools'
+    }
+
+    revert_bam {
+        modules=default_modules
+        container='gatk'
     }
 }

--- a/src/qc_stages.groovy
+++ b/src/qc_stages.groovy
@@ -13,7 +13,7 @@ somalier_extract = {
                 -d $output.dir
                 -f $REF
                 -s $SOMALIER_SITES
-                $input.bam
+                ${input[bam_ext]}
         """
     }
 


### PR DESCRIPTION
Main updates:

1. Reducing file size footprints by changing intermediate BAM files into smaller lossless CRAM files  
2. Removing dangling read groups (those not defined in BAM header) and setting required read group per sample in the source BAM files
3. Removing unnecessary BAM file inputs for Jasmine SV merging
4. Refactoring by removing obsolete Clair3 stages